### PR TITLE
Ignore same file

### DIFF
--- a/lib/merco.js
+++ b/lib/merco.js
@@ -25,7 +25,8 @@ var opts = {
     route: 'build',
     filePath: path.dirname(require.main.filename) + '/public',
     buildPath: path.dirname(require.main.filename) + '/public/js/build/min/',
-    cache: true
+    cache: true,
+    ignoreSameFile: true, //
 };
 
 
@@ -61,7 +62,9 @@ merco.init = function (options) {
          */
 
         res.locals.getJS = function (filename) {
-            res.locals.js.push(filename);
+            if (!opts.ignoreSameFile || !_.contains(res.locals.js, filename)) {
+                res.locals.js.push(filename);
+            }
         };
 
 


### PR DESCRIPTION
For example, sometimes add a same script file multiple times:

<% getJS("/js/lib/jquery-1.10.2.min.js") %>
<% getJS("/js/lib/jquery-1.10.2.min.js") %>

Add a option to ignore the same scripts.
