### PR TITLE
Added server env variable for noMerge

### DIFF
--- a/lib/merco.js
+++ b/lib/merco.js
@@ -79,7 +79,7 @@ merco.init = function (options) {
             var i,
                 scripts = [];
 
-            if ('noMerge' in req.query) {
+            if ('noMerge' in req.query || 'merco_noMerge' in process.env) {
 
                 for (i in res.locals.js) {
                     scripts.push('<script src="' + res.locals.js[i] + '"></script>');


### PR DESCRIPTION
This makes iterating on front-end code faster: adding `NODE_ENV=merco_noMerge` is the same as adding `?noMerge` to every page.
