### PR TITLE
Upgrade Uglify-js

### DIFF
--- a/lib/merco.js
+++ b/lib/merco.js
@@ -10,7 +10,7 @@ const fs = require('fs'),
     path = require('path'),
     crypto = require('crypto'),
     async = require('async'),
-    Terser = require('terser'),
+    { minify } = require('uglify-js'),
     _ = require('lodash');
 
 
@@ -128,65 +128,61 @@ merco.route = function (req, res) {
         file = 'tmp.' + file;
     }
 
-    fs.stat(opts.buildPath + file, function (err, stats) {
-
+    fs.stat(path.join(opts.buildPath, file), function (err, stats) {
         if (opts.cache && stats) {
-            return res.sendFile(path.resolve(opts.buildPath + file));
+            return res.sendFile(path.resolve(path.join(opts.buildPath, file)));
         }
 
-        let result,
-            files = getFiles(encrypted),
-            functions = [];
+        let files = getFiles(encrypted),
+            functions = files.map(f => getFile(path.resolve(path.join(opts.filePath, f))));
 
-        for (let i in files) {
-            files[i] = path.resolve(opts.filePath + files[i]);
-            functions.push(getFile(files[i]));
-        }
-
-        return async.parallel(functions, function (err, results) {
-
+        async.parallel(functions, function (err, results) {
             let mtimestamp = 0,
                 mtime = null,
                 atime = null,
-                validFiles = '';
+                validFiles = {};
 
-            for (let i in results) {
+            results.forEach(result => {
+                if (result) {
+                    let filePath = result.file;
+                    let fileContent = fs.readFileSync(filePath, 'utf8');
+                    validFiles[filePath] = fileContent;
 
-                if (results[i]) {
-
-                    if (results[i].mtime.getTime() > mtimestamp) {
-
-                        mtimestamp = results[i].mtime.getTime();
-                        mtime = results[i].mtime;
-                        atime = results[i].atime;
-
+                    let stats = fs.statSync(filePath);
+                    if (stats.mtime.getTime() > mtimestamp) {
+                        mtimestamp = stats.mtime.getTime();
+                        mtime = stats.mtime;
+                        atime = stats.atime;
                     }
+                }
+            });
 
-                    validFiles += fs.readFileSync(results[i].file);
+            if (Object.keys(validFiles).length) {
+                let result = minify(validFiles, {
+                    compress: true,
+                    mangle: false
+                });
 
+                if (result.error) {
+                    console.error(result.error);
+                    return res.end('something is wrong');
                 }
 
-            }
-
-            if (validFiles.length) {
-                result = Terser.minify(validFiles);
+                fs.writeFile(path.resolve(path.join(opts.buildPath, file)), result.code, function (err) {
+                    if (err) {
+                        return res.status(500).send('Error building js');
+                    } else {
+                        fs.utimes(path.resolve(path.join(opts.buildPath, file)), atime, mtime, function (err) {
+                            if (err) {
+                                return res.status(500).send('Error setting file times');
+                            }
+                            return res.sendFile(path.resolve(path.join(opts.buildPath, file)));
+                        });
+                    }
+                });
             } else {
                 return res.end('something is wrong');
             }
-
-            fs.writeFile(path.resolve(opts.buildPath + file), result.code, function (err) {
-
-                if (err) {
-
-                    return res.status(500).send('Error building js');
-
-                } else {
-
-                    return fs.utimes(path.resolve(opts.buildPath + file), atime, mtime, function (err) {
-                        return res.sendFile(path.resolve(opts.buildPath + file));
-                    });
-                }
-            });
         });
     });
 };

--- a/lib/merco.js
+++ b/lib/merco.js
@@ -10,7 +10,7 @@ const fs = require('fs'),
     path = require('path'),
     crypto = require('crypto'),
     async = require('async'),
-    uglifyJS = require('uglify-js'),
+    Terser = require('terser'),
     _ = require('lodash');
 
 
@@ -148,7 +148,7 @@ merco.route = function (req, res) {
             let mtimestamp = 0,
                 mtime = null,
                 atime = null,
-                validFiles = [];
+                validFiles = '';
 
             for (let i in results) {
 
@@ -162,14 +162,14 @@ merco.route = function (req, res) {
 
                     }
 
-                    validFiles.push(results[i].file);
+                    validFiles += fs.readFileSync(results[i].file);
 
                 }
 
             }
 
             if (validFiles.length) {
-                result = uglifyJS.minify(validFiles);
+                result = Terser.minify(validFiles);
             } else {
                 return res.end('something is wrong');
             }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   "dependencies": {
     "async": "^2.5.0",
     "lodash": "^4.17.4",
-    "terser": "^4.6.6"
+    "terser": "^5.31.6"
   },
   "devDependencies": {
     "chai": "~1.6",
-    "mocha": "~1.0",
-    "sinon": "^4.1.2"
+    "mocha": "^10.7.3",
+    "sinon": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "lodash": "^4.17.4",
-    "terser": "^5.31.6"
+    "uglify-js": "^3.19.1"
   },
   "devDependencies": {
     "chai": "~1.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "lodash": "^4.17.4",
-    "uglify-js": "2.6.0"
+    "terser": "^4.6.6"
   },
   "devDependencies": {
     "chai": "~1.6",


### PR DESCRIPTION
Updated minify to support: https://www.npmjs.com/package/uglify-js#user-content-api-reference

You can minify more than one JavaScript file at a time by using an object for the first argument where the keys are file names and the values are source code:

```
var code = {
    "file1.js": "function add(first, second) { return first + second; }",
    "file2.js": "console.log(add(1 + 2, 3 + 4));"
};
var result = UglifyJS.minify(code);
```